### PR TITLE
Add missing dependencies

### DIFF
--- a/dynamixel_hardware/CMakeLists.txt
+++ b/dynamixel_hardware/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(dynamixel_workbench_toolbox REQUIRED)
@@ -35,6 +37,8 @@ target_include_directories(
 ament_target_dependencies(
   ${PROJECT_NAME}
   rclcpp
+  rclcpp_lifecycle
+  lifecycle_msgs
   hardware_interface
   pluginlib
   dynamixel_workbench_toolbox

--- a/dynamixel_hardware/package.xml
+++ b/dynamixel_hardware/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>lifecycle_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>dynamixel_workbench_toolbox</depend>


### PR DESCRIPTION
This adds rclcpp_lifecycle and lifecycle_msgs as dependencies.
When I compiled ROS2 Galactic from source, the build for dynamixel_control failed, complaining about these. (Not sure why, but when ROS2 is installed from packages on Ubuntu, the build is fine without these.)