### PR TITLE
fix 'CallbackReturn' does not name a type

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -28,6 +28,7 @@
 #include "dynamixel_hardware/visiblity_control.h"
 #include "rclcpp/macros.hpp"
 
+using hardware_interface::CallbackReturn;
 using hardware_interface::return_type;
 
 namespace dynamixel_hardware


### PR DESCRIPTION
Building on rolling, (and perhaps humble too), the following error shows up:

```sh
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:51:1: error: ‘CallbackReturn’ does not name a type
   51 | CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo & info)
      | ^~~~~~~~~~~~~~
```

This change fixes this error.