### PR TITLE
adapt to new hardware interface read and write methods

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -78,10 +78,10 @@ public:
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
-  return_type read() override;
+  return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
-  return_type write() override;
+  return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
 private:
   return_type enable_torque(const bool enabled);

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -226,9 +226,9 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & pr
       joints_[i].state.effort = 0.0;
     }
   }
-  read();
+  read(rclcpp::Time{}, rclcpp::Duration(0, 0));
   reset_command();
-  write();
+  write(rclcpp::Time{}, rclcpp::Duration(0, 0));
 
   return CallbackReturn::SUCCESS;
 }
@@ -239,7 +239,7 @@ CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & 
   return CallbackReturn::SUCCESS;
 }
 
-return_type DynamixelHardware::read()
+return_type DynamixelHardware::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   if (use_dummy_) {
     return return_type::OK;
@@ -288,7 +288,7 @@ return_type DynamixelHardware::read()
   return return_type::OK;
 }
 
-return_type DynamixelHardware::write()
+return_type DynamixelHardware::write(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   if (use_dummy_) {
     for (auto & joint : joints_) {


### PR DESCRIPTION
There were some changes in https://github.com/ros-controls/ros2_control/pull/715, that added a time and period parameter to ``read`` and ``write`` methods. This adapts the packages to the new interface.

FYI, building without the changes causes:
```sh
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_control/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp:81:15: error: ‘hardware_interface::return_type dynamixel_hardware::DynamixelHardware::read()’ marked ‘override’, but does not override
   81 |   return_type read() override;
      |               ^~~~
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_control/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp:84:15: error: ‘hardware_interface::return_type dynamixel_hardware::DynamixelHardware::write()’ marked ‘override’, but does not override
   84 |   return_type write() override;
```

I'm not sure if replacing the ``read()``call with ``read(rclcpp::Time{}, rclcpp::Duration(0, 0));`` is good, (and vice-versa with ``write``). What do you think about that part?