### PR TITLE
rename spawner.py to spawner

### DIFF
--- a/open_manipulator_x_description/launch/open_manipulator_x.launch.py
+++ b/open_manipulator_x_description/launch/open_manipulator_x.launch.py
@@ -50,19 +50,19 @@ def generate_launch_description():
 
         Node(
             package="controller_manager",
-            executable="spawner.py",
+            executable="spawner",
             arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
         ),
 
         Node(
             package="controller_manager",
-            executable="spawner.py",
+            executable="spawner",
             arguments=["velocity_controller", "-c", "/controller_manager"],
         ),
 
         Node(
             package="controller_manager",
-            executable="spawner.py",
+            executable="spawner",
             arguments=["joint_trajectory_controller", "-c", "/controller_manager"],
         ),
 

--- a/pantilt_bot_description/launch/pantilt_bot.launch.py
+++ b/pantilt_bot_description/launch/pantilt_bot.launch.py
@@ -50,19 +50,19 @@ def generate_launch_description():
 
         Node(
             package="controller_manager",
-            executable="spawner.py",
+            executable="spawner",
             arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
         ),
 
         Node(
             package="controller_manager",
-            executable="spawner.py",
+            executable="spawner",
             arguments=["velocity_controller", "-c", "/controller_manager"],
         ),
 
         Node(
             package="controller_manager",
-            executable="spawner.py",
+            executable="spawner",
             arguments=["joint_trajectory_controller", "-c", "/controller_manager"],
         ),
 


### PR DESCRIPTION
In https://github.com/ros-controls/ros2_control/pull/453, ``spawner.py`` was deprecated and replaced by ``spawner``. This PR simply replaces all the calls in the launch files.