### PR TITLE
Use ignition instead of gazebo

### DIFF
--- a/open_manipulator_x_description/CMakeLists.txt
+++ b/open_manipulator_x_description/CMakeLists.txt
@@ -24,8 +24,8 @@ find_package(rviz2 REQUIRED)
 find_package(ros2_control REQUIRED)
 find_package(ros2_controllers REQUIRED)
 find_package(dynamixel_hardware REQUIRED)
-find_package(gazebo_ros REQUIRED)
-find_package(gazebo_ros2_control REQUIRED)
+find_package(ros_ign_gazebo REQUIRED)
+find_package(ign_ros2_control REQUIRED)
 
 install(DIRECTORY
   meshes

--- a/open_manipulator_x_description/launch/open_manipulator_x_gazebo.launch.py
+++ b/open_manipulator_x_description/launch/open_manipulator_x_gazebo.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
     robot_description_config = xacro.process_file(robot_description)
 
     spawn_entity = Node(
-        package="gazebo_ros",
+        package="ros_ign_gazebo",
         executable="spawn_entity.py",
         arguments=["-topic", "robot_description",
                    "-entity", "open_manipulator_x"],
@@ -85,7 +85,7 @@ def generate_launch_description():
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([os.path.join(
-                get_package_share_directory("gazebo_ros"), "launch"), "/gazebo.launch.py"]),
+                get_package_share_directory("ros_ign_gazebo"), "launch"), "/gazebo.launch.py"]),
         ),
 
         Node(

--- a/open_manipulator_x_description/package.xml
+++ b/open_manipulator_x_description/package.xml
@@ -20,8 +20,8 @@
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
   <depend>dynamixel_hardware</depend>
-  <depend>gazebo_ros</depend>
-  <depend>gazebo_ros2_control</depend>
+  <depend>ros_ign_gazebo</depend>
+  <depend>ign_ros2_control</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control_gazebo.xacro
+++ b/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control_gazebo.xacro
@@ -5,7 +5,7 @@
 
     <ros2_control name="${name}" type="system">
       <hardware>
-        <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+        <plugin>ign_ros2_control/IgnitionSystem</plugin>
       </hardware>
       <joint name="joint1">
         <command_interface name="position"/>
@@ -45,7 +45,7 @@
     </ros2_control>
 
     <gazebo>
-      <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+      <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
         <parameters>$(find pantilt_bot_description)/controllers/controllers.yaml</parameters>
       </plugin>
     </gazebo>

--- a/pantilt_bot_description/launch/pantilt_bot_gazebo.launch.py
+++ b/pantilt_bot_description/launch/pantilt_bot_gazebo.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
     robot_description_config = xacro.process_file(robot_description)
 
     spawn_entity = Node(
-        package="gazebo_ros",
+        package="ros_ign_gazebo",
         executable="spawn_entity.py",
         arguments=["-topic", "robot_description",
                    "-entity", "pantilt_bot"],
@@ -85,7 +85,7 @@ def generate_launch_description():
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([os.path.join(
-                get_package_share_directory("gazebo_ros"), "launch"), "/gazebo.launch.py"]),
+                get_package_share_directory("ros_ign_gazebo"), "launch"), "/gazebo.launch.py"]),
         ),
 
         Node(

--- a/pantilt_bot_description/package.xml
+++ b/pantilt_bot_description/package.xml
@@ -21,8 +21,8 @@
   <depend>ros2_controllers</depend>
   <depend>dynamixel_hardware</depend>
   <depend>realsense2_description</depend>
-  <depend>gazebo_ros</depend>
-  <depend>gazebo_ros2_control</depend>
+  <depend>ros_ign_gazebo</depend>
+  <depend>ign_ros2_control</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pantilt_bot_description/urdf/pantilt_bot.ros2_control_gazebo.xacro
+++ b/pantilt_bot_description/urdf/pantilt_bot.ros2_control_gazebo.xacro
@@ -5,7 +5,7 @@
 
     <ros2_control name="${name}" type="system">
       <hardware>
-        <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+        <plugin>ign_ros2_control/IgnitionSystem</plugin>
       </hardware>
       <joint name="joint1">
         <command_interface name="position"/>
@@ -24,7 +24,7 @@
     </ros2_control>
 
     <gazebo>
-      <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+      <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
         <parameters>$(find pantilt_bot_description)/controllers/controllers.yaml</parameters>
       </plugin>
     </gazebo>


### PR DESCRIPTION
This PR replaces gazebo with ignition. The exact changes are listed below.

* ``gazebo_ros`` -> ``ros_ign_gazebo``
* ``gazebo_ros2_control`` -> ``ign_ros2_control``
* ``gazebo_ros2_control/GazeboSystem`` -> ``ign_ros2_control/IgnitionSystem``
* ``<plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">`` -> ``<plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">``