### PR TITLE
Fix unused parameter warning

### DIFF
--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -233,7 +233,7 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & /*
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State &)
+CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & /* previous_state */)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "stop");
   return CallbackReturn::SUCCESS;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -216,7 +216,7 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
   return command_interfaces;
 }
 
-CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & previous_state)
+CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "start");
   for (uint i = 0; i < joints_.size(); i++) {
@@ -233,7 +233,7 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & pr
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & previous_state)
+CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "stop");
   return CallbackReturn::SUCCESS;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -216,7 +216,7 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
   return command_interfaces;
 }
 
-CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State &)
+CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & /* previous_state */)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "start");
   for (uint i = 0; i < joints_.size(); i++) {


### PR DESCRIPTION
Fixes the following warning. This change should be applied to all active distributions, and not just rolling.

```sh
--- stderr: dynamixel_hardware                                                                  
/workspaces/dev_containers_ros2/galactic/galactic-desktop/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp: In member function ‘virtual CallbackReturn dynamixel_hardware::DynamixelHardware::on_activate(const rclcpp_lifecycle::State&)’:
/workspaces/dev_containers_ros2/galactic/galactic-desktop/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:219:79: warning: unused parameter ‘previous_state’ [-Wunused-parameter]
  219 | CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & previous_state)
      |                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/workspaces/dev_containers_ros2/galactic/galactic-desktop/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp: In member function ‘virtual CallbackReturn dynamixel_hardware::DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State&)’:
/workspaces/dev_containers_ros2/galactic/galactic-desktop/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:236:81: warning: unused parameter ‘previous_state’ [-Wunused-parameter]
  236 | CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & previous_state)
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
---
```