### PR TITLE
Fix unused parameter (just rolling branch)

### DIFF
--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -239,7 +239,7 @@ CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & 
   return CallbackReturn::SUCCESS;
 }
 
-return_type DynamixelHardware::read(const rclcpp::Time &, const rclcpp::Duration &)
+return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcpp::Duration & /* period */)
 {
   if (use_dummy_) {
     return return_type::OK;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -239,7 +239,7 @@ CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & 
   return CallbackReturn::SUCCESS;
 }
 
-return_type DynamixelHardware::read(const rclcpp::Time & time, const rclcpp::Duration & period)
+return_type DynamixelHardware::read(const rclcpp::Time &, const rclcpp::Duration &)
 {
   if (use_dummy_) {
     return return_type::OK;
@@ -288,7 +288,7 @@ return_type DynamixelHardware::read(const rclcpp::Time & time, const rclcpp::Dur
   return return_type::OK;
 }
 
-return_type DynamixelHardware::write(const rclcpp::Time & time, const rclcpp::Duration & period)
+return_type DynamixelHardware::write(const rclcpp::Time &, const rclcpp::Duration &)
 {
   if (use_dummy_) {
     for (auto & joint : joints_) {

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -288,7 +288,7 @@ return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcp
   return return_type::OK;
 }
 
-return_type DynamixelHardware::write(const rclcpp::Time &, const rclcpp::Duration &)
+return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclcpp::Duration & /* period */)
 {
   if (use_dummy_) {
     for (auto & joint : joints_) {


### PR DESCRIPTION
This fixes the following unused parameter warnings specific to the rolling branch:

```
/home/ijnek/tmp_workspaces/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp: In member function ‘virtual hardware_interface::return_type dynamixel_hardware::DynamixelHardware::read(const rclcpp::Time&, const rclcpp::Duration&)’:
/home/ijnek/tmp_workspaces/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:242:58: warning: unused parameter ‘time’ [-Wunused-parameter]
  242 | return_type DynamixelHardware::read(const rclcpp::Time & time, const rclcpp::Duration & period)
      |                                     ~~~~~~~~~~~~~~~~~~~~~^~~~
/home/ijnek/tmp_workspaces/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:242:89: warning: unused parameter ‘period’ [-Wunused-parameter]
  242 | turn_type DynamixelHardware::read(const rclcpp::Time & time, const rclcpp::Duration & period)
      |                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~

/home/ijnek/tmp_workspaces/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp: In member function ‘virtual hardware_interface::return_type dynamixel_hardware::DynamixelHardware::write(const rclcpp::Time&, const rclcpp::Duration&)’:
/home/ijnek/tmp_workspaces/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:291:59: warning: unused parameter ‘time’ [-Wunused-parameter]
  291 | return_type DynamixelHardware::write(const rclcpp::Time & time, const rclcpp::Duration & period)
      |                                      ~~~~~~~~~~~~~~~~~~~~~^~~~
/home/ijnek/tmp_workspaces/quasor_ws/src/dynamixel_control/dynamixel_hardware/src/dynamixel_hardware.cpp:291:90: warning: unused parameter ‘period’ [-Wunused-parameter]
  291 | urn_type DynamixelHardware::write(const rclcpp::Time & time, const rclcpp::Duration & period)
      |                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
```