### PR TITLE
Comment out unused paramter

### DIFF
--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -216,7 +216,7 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
   return command_interfaces;
 }
 
-CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & previous_state)
+CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & /* previous_state */)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "start");
   for (uint i = 0; i < joints_.size(); i++) {
@@ -233,7 +233,7 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & pr
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & previous_state)
+CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & /* previous_state */)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "stop");
   return CallbackReturn::SUCCESS;


### PR DESCRIPTION
Fixes the following warning:

```sh
--- stderr: dynamixel_hardware        
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_hardware/src/dynamixel_hardware.cpp: In member function ‘virtual hardware_interface::CallbackReturn dynamixel_hardware::DynamixelHardware::on_activate(const rclcpp_lifecycle::State&)’:
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_hardware/src/dynamixel_hardware.cpp:219:79: warning: unused parameter ‘previous_state’ [-Wunused-parameter]
  219 | amixelHardware::on_activate(const rclcpp_lifecycle::State & previous_state)
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~

/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_hardware/src/dynamixel_hardware.cpp: In member function ‘virtual hardware_interface::CallbackReturn dynamixel_hardware::DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State&)’:
/home/ijnek/tmp_workspaces/dynamixel_control_ws/src/dynamixel_hardware/src/dynamixel_hardware.cpp:236:81: warning: unused parameter ‘previous_state’ [-Wunused-parameter]
  236 | ixelHardware::on_deactivate(const rclcpp_lifecycle::State & previous_state)
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~

---
```

Should be backported to **galactic** and **humble** too.