### PR TITLE
Adding back in ros_ign_gazebo and ign_ros2_control dependency

### DIFF
--- a/open_manipulator_x_description/package.xml
+++ b/open_manipulator_x_description/package.xml
@@ -20,6 +20,8 @@
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
   <depend>dynamixel_hardware</depend>
+  <depend>ros_ign_gazebo</depend>
+  <depend>ign_ros2_control</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/pantilt_bot_description/package.xml
+++ b/pantilt_bot_description/package.xml
@@ -20,7 +20,8 @@
   <depend>ros2_control</depend>
   <depend>ros2_controllers</depend>
   <depend>dynamixel_hardware</depend>
-  <depend>realsense2_description</depend>
+  <depend>ros_ign_gazebo</depend>
+  <depend>ign_ros2_control</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Addresses: https://github.com/youtalk/dynamixel_control/pull/35#issuecomment-1280696915

But don't call find_package from within in CMakeLists.txt. They are only used in URDF, so a find_package should't be necessary.

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>