### PR TITLE
Use env-hooks to allow ignition gazebo to find meshes of robot

### DIFF
--- a/open_manipulator_x_description/CMakeLists.txt
+++ b/open_manipulator_x_description/CMakeLists.txt
@@ -44,4 +44,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+# Environment hooks
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.dsv.in")
+
 ament_package()

--- a/open_manipulator_x_description/env-hooks/open_manipulator_x_description.dsv.in
+++ b/open_manipulator_x_description/env-hooks/open_manipulator_x_description.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;/$(ros2 pkg prefix open_manipulator_x_description)/share/

--- a/pantilt_bot_description/CMakeLists.txt
+++ b/pantilt_bot_description/CMakeLists.txt
@@ -45,4 +45,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+# Environment hooks
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.dsv.in")
+
 ament_package()

--- a/pantilt_bot_description/env-hooks/pantilt_bot_description.dsv.in
+++ b/pantilt_bot_description/env-hooks/pantilt_bot_description.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;/$(ros2 pkg prefix pantilt_bot_description)/share/


### PR DESCRIPTION
Although this isn't well documented, this is standard practice for adding the meshes of the package to IGN_GAZEBO_RESOURCE_PATH for ign gazebo to find.

Similar thing done in https://github.com/chapulina/dolly/tree/galactic/dolly_gazebo