### PR TITLE
Replace spawn_entity with create due to deprecation

### DIFF
--- a/open_manipulator_x_description/launch/open_manipulator_x_gazebo.launch.py
+++ b/open_manipulator_x_description/launch/open_manipulator_x_gazebo.launch.py
@@ -34,9 +34,9 @@ def generate_launch_description():
         package_name), "urdf", robot_name + ".urdf.xacro")
     robot_description_config = xacro.process_file(robot_description)
 
-    spawn_entity = Node(
+    create = Node(
         package="ros_ign_gazebo",
-        executable="spawn_entity.py",
+        executable="create",
         arguments=["-topic", "robot_description",
                    "-entity", "open_manipulator_x"],
         output="screen"
@@ -64,7 +64,7 @@ def generate_launch_description():
     return LaunchDescription([
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=spawn_entity,
+                target_action=create,
                 on_exit=[joint_state_broadcaster],
             )
         ),
@@ -96,7 +96,7 @@ def generate_launch_description():
                 {"robot_description": robot_description_config.toxml()}],
             output="screen"),
 
-        spawn_entity,
+        create,
 
         Node(
             package="rviz2",

--- a/pantilt_bot_description/launch/pantilt_bot_gazebo.launch.py
+++ b/pantilt_bot_description/launch/pantilt_bot_gazebo.launch.py
@@ -34,9 +34,9 @@ def generate_launch_description():
         package_name), "urdf", robot_name + ".urdf.xacro")
     robot_description_config = xacro.process_file(robot_description)
 
-    spawn_entity = Node(
+    create = Node(
         package="ros_ign_gazebo",
-        executable="spawn_entity.py",
+        executable="create",
         arguments=["-topic", "robot_description",
                    "-entity", "pantilt_bot"],
         output="screen"
@@ -64,7 +64,7 @@ def generate_launch_description():
     return LaunchDescription([
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=spawn_entity,
+                target_action=create,
                 on_exit=[joint_state_broadcaster],
             )
         ),
@@ -96,7 +96,7 @@ def generate_launch_description():
                 {"robot_description": robot_description_config.toxml()}],
             output="screen"),
 
-        spawn_entity,
+        create,
 
         Node(
             package="rviz2",


### PR DESCRIPTION
spawn_entity.py doesn't work, ``create`` must be used.

See usage of ``ros2 run ros_ign_gazebo create ...`` in [ros_ign_gazebo's README](https://github.com/gazebosim/ros_gz/tree/galactic/ros_ign_gazebo).