### PR TITLE
Feature/humble/current based control

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -100,6 +100,7 @@ private:
 
   CallbackReturn set_joint_positions();
   CallbackReturn set_joint_velocities();
+  CallbackReturn set_joint_currents();
   CallbackReturn set_joint_params();
 
   DynamixelWorkbench dynamixel_workbench_;

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -109,7 +109,6 @@ private:
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::NoControl};
   ControlMode prev_control_mode_{ControlMode::NoControl};
-  bool mode_changed_{false};
   bool use_dummy_{false};
 };
 }  // namespace dynamixel_hardware

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -44,7 +44,6 @@ struct Joint
 {
   JointValue state{};
   JointValue command{};
-  JointValue prev_command{};
 };
 
 enum class ControlMode {

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -50,7 +50,7 @@ enum class ControlMode {
   Position,
   Velocity,
   Torque,
-  Currrent,
+  Current,
   ExtendedPosition,
   MultiTurn,
   CurrentBasedPosition,

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -94,7 +94,7 @@ public:
 private:
   return_type enable_torque(const bool enabled);
 
-  return_type set_control_mode(const ControlMode & mode, const bool force_set = false);
+  return_type set_control_mode(const ControlMode & mode);
 
   return_type reset_command();
 
@@ -108,6 +108,7 @@ private:
   std::vector<uint8_t> joint_ids_;
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::NoControl};
+  ControlMode prev_control_mode_{ControlMode::NoControl};
   bool mode_changed_{false};
   bool use_dummy_{false};
 };

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -106,6 +106,8 @@ private:
   std::map<const char * const, const ControlItem *> control_items_;
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
+  std::vector<uint8_t> joint_ids_ttl_;
+  std::vector<uint8_t> joint_ids_rs_;
   bool torque_enabled_{false};
   ControlMode control_mode_{ControlMode::NoControl};
   ControlMode prev_control_mode_{ControlMode::NoControl};

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -74,13 +74,12 @@ public:
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
-  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
-
-  DYNAMIXEL_HARDWARE_PUBLIC
   return_type prepare_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
     const std::vector<std::string> & stop_interfaces) override;
-
+  
+  DYNAMIXEL_HARDWARE_PUBLIC
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -55,6 +55,7 @@ enum class ControlMode {
   MultiTurn,
   CurrentBasedPosition,
   PWM,
+  NoControl,
 };
 
 class DynamixelHardware
@@ -74,6 +75,12 @@ public:
 
   DYNAMIXEL_HARDWARE_PUBLIC
   CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  DYNAMIXEL_HARDWARE_PUBLIC
+  return_type prepare_command_mode_switch(
+    const std::vector<std::string> & start_interfaces,
+    const std::vector<std::string> & stop_interfaces) override;
+
 
   DYNAMIXEL_HARDWARE_PUBLIC
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
@@ -100,7 +107,7 @@ private:
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
   bool torque_enabled_{false};
-  ControlMode control_mode_{ControlMode::Position};
+  ControlMode control_mode_{ControlMode::NoControl};
   bool mode_changed_{false};
   bool use_dummy_{false};
 };

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -80,7 +80,7 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
 
   if (
     info_.hardware_parameters.find("use_dummy") != info_.hardware_parameters.end() &&
-    info_.hardware_parameters.at("use_dummy") == "true") {
+    (info_.hardware_parameters.at("use_dummy") == "true" || info_.hardware_parameters.at("use_dummy") == "True")) {
     use_dummy_ = true;
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "dummy mode");
     return CallbackReturn::SUCCESS;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -67,9 +67,6 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
     joints_[i].command.position = std::numeric_limits<double>::quiet_NaN();
     joints_[i].command.velocity = std::numeric_limits<double>::quiet_NaN();
     joints_[i].command.effort = std::numeric_limits<double>::quiet_NaN();
-    joints_[i].prev_command.position = joints_[i].command.position;
-    joints_[i].prev_command.velocity = joints_[i].command.velocity;
-    joints_[i].prev_command.effort = joints_[i].command.effort;
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "joint_id %d: %d", i, joint_ids_[i]);
   }
 
@@ -284,41 +281,9 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
 {
   if (use_dummy_) {
     for (auto & joint : joints_) {
-      joint.prev_command.position = joint.command.position;
       joint.state.position = joint.command.position;
     }
     return return_type::OK;
-  }
-
-  // Velocity control
-  if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.velocity != j.prev_command.velocity; })) {
-    set_control_mode(ControlMode::Velocity);
-    if(mode_changed_)
-    {
-      set_joint_params();
-    }
-    set_joint_velocities();
-    return return_type::OK;
-  }
-  
-  // Position control
-  if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.position != j.prev_command.position; })) {
-    set_control_mode(ControlMode::Position);
-    if(mode_changed_)
-    {
-      set_joint_params();
-    }
-    set_joint_positions();
-    return return_type::OK;
-  }
-
-  // Effort control
-  if (std::any_of(
-               joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.effort != 0.0; })) {
-    RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "Effort control is not implemented");
-    return return_type::ERROR;
   }
 
   // if all command values are unchanged, then remain in existing control mode and set corresponding command values
@@ -436,9 +401,6 @@ return_type DynamixelHardware::reset_command()
     joints_[i].command.position = joints_[i].state.position;
     joints_[i].command.velocity = 0.0;
     joints_[i].command.effort = 0.0;
-    joints_[i].prev_command.position = joints_[i].command.position;
-    joints_[i].prev_command.velocity = joints_[i].command.velocity;
-    joints_[i].prev_command.effort = joints_[i].command.effort;
   }
 
   return return_type::OK;
@@ -452,7 +414,6 @@ CallbackReturn DynamixelHardware::set_joint_positions()
 
   std::copy(joint_ids_.begin(), joint_ids_.end(), ids.begin());
   for (uint i = 0; i < ids.size(); i++) {
-    joints_[i].prev_command.position = joints_[i].command.position;
     commands[i] = dynamixel_workbench_.convertRadian2Value(
       ids[i], static_cast<float>(joints_[i].command.position));
   }
@@ -471,7 +432,6 @@ CallbackReturn DynamixelHardware::set_joint_velocities()
 
   std::copy(joint_ids_.begin(), joint_ids_.end(), ids.begin());
   for (uint i = 0; i < ids.size(); i++) {
-    joints_[i].prev_command.velocity = joints_[i].command.velocity;
     commands[i] = dynamixel_workbench_.convertVelocity2Value(
       ids[i], static_cast<float>(joints_[i].command.velocity));
   }

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -424,7 +424,6 @@ return_type DynamixelHardware::enable_torque(const bool enabled)
 return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
 {
   const char * log = nullptr;
-  mode_changed_ = false;
 
   if (mode == ControlMode::NoControl) {
     if (torque_enabled_) {
@@ -438,7 +437,6 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Position control,but no torque mode");
-    mode_changed_ = true;
 
     return return_type::OK;
   }
@@ -455,7 +453,6 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Velocity control");
-    mode_changed_ = true;
 
     enable_torque(true);
     return return_type::OK;
@@ -473,7 +470,6 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode)
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Position control");
-    mode_changed_ = true;
 
     enable_torque(true);
     return return_type::OK;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -200,6 +200,8 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
       info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
   }
 
   return command_interfaces;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -196,12 +196,20 @@ std::vector<hardware_interface::StateInterface> DynamixelHardware::export_state_
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "export_state_interfaces");
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (uint i = 0; i < info_.joints.size(); i++) {
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].state.position));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].state.velocity));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].state.effort));
+    for(auto joint_interface:info_.joints[i].state_interfaces){
+      if(joint_interface.name == hardware_interface::HW_IF_POSITION){
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].state.position));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_VELOCITY){
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].state.velocity));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_EFFORT){
+        state_interfaces.emplace_back(hardware_interface::StateInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].state.effort));
+      }
+    }
   }
 
   return state_interfaces;
@@ -212,12 +220,20 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "export_command_interfaces");
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   for (uint i = 0; i < info_.joints.size(); i++) {
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
+    for(auto joint_interface:info_.joints[i].command_interfaces){
+      if(joint_interface.name == hardware_interface::HW_IF_POSITION){
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_VELOCITY){
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
+      }
+      if(joint_interface.name == hardware_interface::HW_IF_EFFORT){
+        command_interfaces.emplace_back(hardware_interface::CommandInterface(
+          info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
+      }
+    }
   }
 
   return command_interfaces;


### PR DESCRIPTION
# Implementation of Current Mode and CurrentBasedPosition Mode & Proposal for Additional Features

I have implemented control for Current and CurrentBasedPosition. 
I am proposing this as a draft pull request for the following reasons:

- There are questions regarding the implemented features and the method of implementation.
- It includes changes/additions to 4 features.
- It contains significant changes to the process.

If you approve this proposal, we will consider making improvements and other modifications/splitting the PR. If you do not approve, we will reject this proposal.

## Tested Environment

- NVIDIA Orin Nano Developer Kit
    - Jetpack 5.1.1 (L4T 35.3.1)
    - ROS 2: Humble
- U2D2
- U2D2 Power Hub
- Dynamixel Servo Motors
    - XM 540-W150-T
        - TTL Protocol
    - XW540-T140-R
        - RS485 Protocol

## Implemented Features

1. Current Mode and CurrentBasedPosition Control Mode
    - Change in mode switching method
    - Addition of modes
2. Addition of Interface for Joint State/Command
3. Control of both RS485 and TTL motors in a single circuit
4. Minor corrections

## Changes

### 1. Current Mode and CurrentBasedPosition Control Mode

#### 1.1. Addition of Mode Switching Method

Commits(Add): [c06216f1eed03124ba4bc1d409a03b0acc5b0129](https://github.com/moyashibeans/dynamixel_hardware/commit/c06216f1eed03124ba4bc1d409a03b0acc5b0129), [86da4367412476249e2bdaabd6d00a922e3355b6](https://github.com/moyashibeans/dynamixel_hardware/commit/86da4367412476249e2bdaabd6d00a922e3355b6), 
Commits(Removal): [b44fcaa315cb91aad107c6bbcaa22694d5e54334](https://github.com/moyashibeans/dynamixel_hardware/commit/b44fcaa315cb91aad107c6bbcaa22694d5e54334), [9186d0603c8580bb9e1ad51028bd6bb38f5568e6](https://github.com/moyashibeans/dynamixel_hardware/commit/9186d0603c8580bb9e1ad51028bd6bb38f5568e6)

- Add code:
    - Enabled mode switching through the `prepare_command_mode_switch` function using information from `hardware_interface`.
    - Allowed switching to CurrentBasedPosition Control Mode when both effort and position interfaces are active.
- Remove code:
    - Removed the method of switching modes based on the difference from `prev_command_` value of the previous loop.
    - Changed to switch/change modes only when there are changes in the control_interface instead of every loop.

#### 1.2. Addition of Modes

Commits: [b59cdc4f3df7b176f1524d8c4e7c0adaf47aca35](https://github.com/moyashibeans/dynamixel_hardware/commit/b59cdc4f3df7b176f1524d8c4e7c0adaf47aca35), [faed640e35536898300a8e3c882e048896255ce4](https://github.com/moyashibeans/dynamixel_hardware/commit/faed640e35536898300a8e3c882e048896255ce4)

- Conducted currentMode control via the effort_controller.
- Implemented CurrentBasedPosition Control Mode, controllable from commands via both effort_controller and position_controller interfaces.

### 2. Addition of Joint State/Command Interface

Commit: [193dc8512ad0ded41da339707ccc96db1c2eee2d](https://github.com/moyashibeans/dynamixel_hardware/commit/193dc8512ad0ded41da339707ccc96db1c2eee2d)

- Set the number of hardware_interface joints based on `joint` `command_interface`/`state_interface` information from `urdf`.

### 3. Control of both RS485 and TTL Motors in a Single Circuit

Commit: [3eb921d7cb2f669eece591addb83d6564798e757](https://github.com/moyashibeans/dynamixel_hardware/commit/3eb921d7cb2f669eece591addb83d6564798e757)

According to U2D2's [specifications](https://emanual.robotis.com/docs/en/parts/interface/u2d2/#:~:text=In%20addition,%20when%20using%20Bulk%20Read%20and%20Sync%20Read), TTL and RS485 cannot be read simultaneously. To overcome this limitation, we split the joints by protocol, allowing for separate reads. This approach ensures functionality even when both protocols are used together.


### 4. Minor Corrections

- Typo fixed [85df0b974e2daa29fe9aa51480d29211bd59a878](https://github.com/moyashibeans/dynamixel_hardware/commit/85df0b974e2daa29fe9aa51480d29211bd59a878)
- Made `use_dummy` work in UpperCase as well [909f7de545d57e2af19b857c2604f0d5fb06781e](https://github.com/moyashibeans/dynamixel_hardware/commit/909f7de545d57e2af19b857c2604f0d5fb06781e)
    - This change was made to accommodate parameters passed via `xacro` `args` that become UpperCase.

## Questions

- Regarding feature 1, in using `prepare_command_mode_switch`, it was necessary to define the behavior when `commandInterfaces` do not exist at startup.
    - For this reason, I added a `NoControl` mode to the `ControlMode` enum, although it does not exist in Dynamixel. Is this acceptable?
- For feature 2, it can be argued that reading interfaces from `xacro` is more correct. However, I do not see a necessity to intentionally limit the number of interfaces. Is the implementation of this feature necessary?
- Regarding feature 3, it became possible to control motors with different protocols. This was a necessary feature in the environment I used, but is it necessary to include this in the PR?