### PR TITLE
Delayed Read Write Calls till after `on_activate()` is completed

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -104,6 +104,7 @@ private:
   ControlMode control_mode_{ControlMode::Position};
   bool mode_changed_{false};
   bool use_dummy_{false};
+  bool activated_{false};
 };
 }  // namespace dynamixel_hardware
 

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -225,11 +225,12 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & /*
       joints_[i].state.effort = 0.0;
     }
   }
+
+  activated_ = true;
+  
   read(rclcpp::Time{}, rclcpp::Duration(0, 0));
   reset_command();
   write(rclcpp::Time{}, rclcpp::Duration(0, 0));
-
-  activated_ = true;
 
   return CallbackReturn::SUCCESS;
 }

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -229,12 +229,16 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & /*
   reset_command();
   write(rclcpp::Time{}, rclcpp::Duration(0, 0));
 
+  activated_ = true;
+
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn DynamixelHardware::on_deactivate(
   const rclcpp_lifecycle::State & /* previous_state */)
 {
+  activated_ = false;
+  
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "stop");
   return CallbackReturn::SUCCESS;
 }
@@ -243,6 +247,11 @@ return_type DynamixelHardware::read(
   const rclcpp::Time & /* time */,
   const rclcpp::Duration & /* period */)
 {
+  if(!activated_)
+  {
+    return return_type::OK;
+  }
+
   if (use_dummy_) {
     return return_type::OK;
   }
@@ -290,7 +299,6 @@ return_type DynamixelHardware::read(
     joints_[i].state.velocity = dynamixel_workbench_.convertValue2Velocity(ids[i], velocities[i]);
     joints_[i].state.effort = dynamixel_workbench_.convertValue2Current(currents[i]);
   }
-
   return return_type::OK;
 }
 
@@ -298,6 +306,11 @@ return_type DynamixelHardware::write(
   const rclcpp::Time & /* time */,
   const rclcpp::Duration & /* period */)
 {
+  if(!activated_)
+  {
+    return return_type::OK;
+  }
+
   if (use_dummy_) {
     for (auto & joint : joints_) {
       joint.prev_command.position = joint.command.position;


### PR DESCRIPTION
## In this PR
- Fixed #88 (refer abab217f3d3c2a7a3618062cf50228268b6caab1)
- Added bool variable that exits out of the read and write calls till on_activate is completed

## How was this tested?
- Tested on Humble with XC330-M288T in Position Control Mode at 200HZ with JTC