### PR TITLE
Add gear_ratio parameter

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -45,6 +45,7 @@ struct Joint
   JointValue state{};
   JointValue command{};
   JointValue prev_command{};
+  double gear_ratio{1.0};
 };
 
 enum class ControlMode


### PR DESCRIPTION
I added the `gear_ratio` parameter to enable combining gears.
Since the default value is set to 1.0, there will be no changes to the existing behavior.

- fix #94 