### PR TITLE
Add support rising tag

### DIFF
--- a/dynamixel_hardware/CMakeLists.txt
+++ b/dynamixel_hardware/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(lifecycle_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(dynamixel_workbench_toolbox REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
 add_library(
   ${PROJECT_NAME}

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -45,6 +45,7 @@ struct Joint
   JointValue state{};
   JointValue command{};
   JointValue prev_command{};
+  double rising_offset{0.0};
 };
 
 enum class ControlMode

--- a/dynamixel_hardware/package.xml
+++ b/dynamixel_hardware/package.xml
@@ -14,6 +14,7 @@
   <depend>lifecycle_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
+  <depend>tinyxml2_vendor</depend>
   <depend>dynamixel_workbench_toolbox</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
I have implemented the ability to apply the `rising` attribute in the `calibration` tag of the URDF.

- fix #93 