### PR TITLE
Support ExtendedPostiion and Current control; Implement on_configure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Set update schedule for GitHub Actions
+# (https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/build_and_test_foxy.yaml
+++ b/.github/workflows/build_and_test_foxy.yaml
@@ -23,10 +23,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           # The testing repository will be used
           use-ros2-testing: true
-      - uses: ros-tooling/action-ros-ci@v0.2
+      - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: foxy

--- a/.github/workflows/build_and_test_humble.yaml
+++ b/.github/workflows/build_and_test_humble.yaml
@@ -22,10 +22,10 @@ jobs:
       image: ubuntu:jammy
 
     steps:
-      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           # The testing repository will be used
           use-ros2-testing: true
-      - uses: ros-tooling/action-ros-ci@v0.2
+      - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: humble

--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -16,16 +16,16 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The runner will be ubuntu-latest, with a clean ubuntu jammy container
+    # The runner will be ubuntu-latest, with a clean ubuntu noble container
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:jammy
+      image: ubuntu:noble
 
     steps:
-      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/setup-ros@v0.7
         with:
           # The testing repository will be used
           use-ros2-testing: true
-      - uses: ros-tooling/action-ros-ci@v0.2
+      - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: rolling

--- a/dynamixel_hardware/CHANGELOG.rst
+++ b/dynamixel_hardware/CHANGELOG.rst
@@ -1,0 +1,29 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dynamixel_hardware
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.6.0 (2024-04-24)
+------------------
+* Adhere to style guide (`#73 <https://github.com/dynamixel-community/dynamixel_hardware/issues/73>`_)
+* Revised control mode changes, added set_joint_params (`#65 <https://github.com/dynamixel-community/dynamixel_hardware/issues/65>`_)
+  * revised control mode changes, added set_params
+  * removed unnecessary comment
+* Missing comma for setting Position_D_Gain (`#56 <https://github.com/dynamixel-community/dynamixel_hardware/issues/56>`_)
+  * comment out unused paramter
+  * A comma is missing for setting the Position_D_Gain
+* Contributors: Geoff Sokoll, Kenji Brameld, Lass6230, Yutaka Kondo
+
+0.3.1 (2022-11-17)
+------------------
+* Merge pull request `#39 <https://github.com/youtalk/dynamixel_control/issues/39>`_ from ijnek/ijnek-unused-parameters
+* Merge pull request `#31 <https://github.com/youtalk/dynamixel_control/issues/31>`_ from ijnek/ijnek-unused-parameter-2
+* Merge pull request `#25 <https://github.com/youtalk/dynamixel_control/issues/25>`_ from ijnek/ijnek-new-hardware-interface
+* Merge pull request `#24 <https://github.com/youtalk/dynamixel_control/issues/24>`_ from ijnek/ijnek-add-callbackreturn-reference
+* Merge pull request `#20 <https://github.com/youtalk/dynamixel_control/issues/20>`_ from pdenes/add-extra-params
+* Merge pull request `#19 <https://github.com/youtalk/dynamixel_control/issues/19>`_ from pdenes/add-dependencies
+* Merge pull request `#17 <https://github.com/youtalk/dynamixel_control/issues/17>`_ from youtalk/galactic
+* Merge pull request `#16 <https://github.com/youtalk/dynamixel_control/issues/16>`_ from Schnilz/main
+* Merge pull request `#13 <https://github.com/youtalk/dynamixel_control/issues/13>`_ from youtalk/change-loglevel
+* Merge pull request `#10 <https://github.com/youtalk/dynamixel_control/issues/10>`_ from youtalk/joint-id
+* Merge pull request `#1 <https://github.com/youtalk/dynamixel_control/issues/1>`_ from youtalk/velocity-control
+* Contributors: Kenji Brameld, Nils Schulte, Pal Denes, Yutaka Kondo

--- a/dynamixel_hardware/CMakeLists.txt
+++ b/dynamixel_hardware/CMakeLists.txt
@@ -42,7 +42,7 @@ ament_target_dependencies(
   hardware_interface
   pluginlib
   dynamixel_workbench_toolbox
-  )
+)
 
 
 pluginlib_export_plugin_description_file(hardware_interface dynamixel_hardware.xml)

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -51,7 +51,7 @@ enum class ControlMode {
   Position,
   Velocity,
   Torque,
-  Currrent,
+  Current,
   ExtendedPosition,
   MultiTurn,
   CurrentBasedPosition,
@@ -94,6 +94,7 @@ private:
 
   CallbackReturn set_joint_positions();
   CallbackReturn set_joint_velocities();
+  CallbackReturn set_joint_currents();
   CallbackReturn set_joint_params();
 
   DynamixelWorkbench dynamixel_workbench_;

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -17,13 +17,13 @@
 
 #include <dynamixel_workbench_toolbox/dynamixel_workbench.h>
 
+#include <map>
+#include <vector>
+
 #include <hardware_interface/handle.hpp>
 #include <hardware_interface/hardware_info.hpp>
 #include <hardware_interface/system_interface.hpp>
 #include <rclcpp_lifecycle/state.hpp>
-
-#include <map>
-#include <vector>
 
 #include "dynamixel_hardware/visiblity_control.h"
 #include "rclcpp/macros.hpp"
@@ -47,7 +47,8 @@ struct Joint
   JointValue prev_command{};
 };
 
-enum class ControlMode {
+enum class ControlMode
+{
   Position,
   Velocity,
   Torque,
@@ -58,8 +59,7 @@ enum class ControlMode {
   PWM,
 };
 
-class DynamixelHardware
-: public hardware_interface::SystemInterface
+class DynamixelHardware : public hardware_interface::SystemInterface
 {
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(DynamixelHardware)

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -68,6 +68,9 @@ public:
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  DYNAMIXEL_HARDWARE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
@@ -102,7 +105,7 @@ private:
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
   bool torque_enabled_{false};
-  ControlMode control_mode_{ControlMode::Position};
+  ControlMode control_mode_{ControlMode::ExtendedPosition};
   bool mode_changed_{false};
   bool use_dummy_{false};
 };

--- a/dynamixel_hardware/package.xml
+++ b/dynamixel_hardware/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_hardware</name>
-  <version>0.0.0</version>
+  <version>0.6.0</version>
   <description>ros2_control hardware for ROBOTIS Dynamixel</description>
   <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
   <license>Apache 2.0</license>

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -102,7 +102,7 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
   }
 
   enable_torque(false);
-  set_control_mode(ControlMode::Position, true);
+  set_control_mode(ControlMode::ExtendedPosition, true);
   set_joint_params();
   enable_torque(true);
 
@@ -305,7 +305,7 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
   // Position control
   if (std::any_of(
         joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.position != j.prev_command.position; })) {
-    set_control_mode(ControlMode::Position);
+    set_control_mode(ControlMode::ExtendedPosition);
     if(mode_changed_)
     {
       set_joint_params();
@@ -327,7 +327,7 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
       set_joint_velocities();
       return return_type::OK;
       break;
-    case ControlMode::Position:
+    case ControlMode::ExtendedPosition:
       set_joint_positions();
       return return_type::OK;
       break;
@@ -396,23 +396,23 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
     return return_type::OK;
   }
 
-  if (mode == ControlMode::Position && (force_set || control_mode_ != ControlMode::Position)) {
+  if (mode == ControlMode::ExtendedPosition && (force_set || control_mode_ != ControlMode::ExtendedPosition)) {
     bool torque_enabled = torque_enabled_;
     if (torque_enabled) {
       enable_torque(false);
     }
 
     for (uint i = 0; i < joint_ids_.size(); ++i) {
-      if (!dynamixel_workbench_.setPositionControlMode(joint_ids_[i], &log)) {
+      if (!dynamixel_workbench_.setExtendedPositionControlMode(joint_ids_[i], &log)) {
         RCLCPP_FATAL(rclcpp::get_logger(kDynamixelHardware), "%s", log);
         return return_type::ERROR;
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Position control");
-    if(control_mode_ != ControlMode::Position)
+    if(control_mode_ != ControlMode::ExtendedPosition)
     {
       mode_changed_ = true;
-      control_mode_ = ControlMode::Position;
+      control_mode_ = ControlMode::ExtendedPosition;
     }
 
     if (torque_enabled) {
@@ -421,7 +421,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
     return return_type::OK;
   }
   
-  if (control_mode_ != ControlMode::Velocity && control_mode_ != ControlMode::Position) {
+  if (control_mode_ != ControlMode::Velocity && control_mode_ != ControlMode::ExtendedPosition) {
     RCLCPP_FATAL(
       rclcpp::get_logger(kDynamixelHardware), "Only position/velocity control are implemented");
     return return_type::ERROR;

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -308,6 +308,10 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
     for (auto & joint : joints_) {
       joint.prev_command.position = joint.command.position;
       joint.state.position = joint.command.position;
+      joint.prev_command.velocity = joint.command.velocity;
+      joint.state.velocity = joint.command.velocity;
+      joint.prev_command.effort = joint.command.effort;
+      joint.state.effort = joint.command.effort;
     }
     return return_type::OK;
   }

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -206,10 +206,6 @@ CallbackReturn DynamixelHardware::on_configure(const rclcpp_lifecycle::State & /
     return CallbackReturn::ERROR;
   }
 
-  // for (uint i = 0; i < joints_.size(); i++) {
-  //   RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "In on_configure, joint%d pos: %f", i, joints_[i].state.position);
-  // }
-
   enable_torque(false);
   set_control_mode(ControlMode::ExtendedPosition, true);
   set_joint_params();
@@ -285,7 +281,7 @@ return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcp
 
   if (!dynamixel_workbench_.syncRead(
         kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(), &log)) {
-    RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "[in syncRead() in read()] %s", log);
+    RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
     return return_type::ERROR;
   }
 

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -77,7 +77,8 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
 
   if (
     info_.hardware_parameters.find("use_dummy") != info_.hardware_parameters.end() &&
-    info_.hardware_parameters.at("use_dummy") == "true") {
+    info_.hardware_parameters.at("use_dummy") == "true")
+  {
     use_dummy_ = true;
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "dummy mode");
     return CallbackReturn::SUCCESS;
@@ -156,15 +157,17 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
   control_items_[kPresentCurrentItem] = present_current;
 
   if (!dynamixel_workbench_.addSyncWriteHandler(
-        control_items_[kGoalPositionItem]->address, control_items_[kGoalPositionItem]->data_length,
-        &log)) {
+      control_items_[kGoalPositionItem]->address, control_items_[kGoalPositionItem]->data_length,
+      &log))
+  {
     RCLCPP_FATAL(rclcpp::get_logger(kDynamixelHardware), "%s", log);
     return CallbackReturn::ERROR;
   }
 
   if (!dynamixel_workbench_.addSyncWriteHandler(
-        control_items_[kGoalVelocityItem]->address, control_items_[kGoalVelocityItem]->data_length,
-        &log)) {
+      control_items_[kGoalVelocityItem]->address, control_items_[kGoalVelocityItem]->data_length,
+      &log))
+  {
     RCLCPP_FATAL(rclcpp::get_logger(kDynamixelHardware), "%s", log);
     return CallbackReturn::ERROR;
   }
@@ -179,8 +182,8 @@ CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo
   uint16_t start_address = std::min(
     control_items_[kPresentPositionItem]->address, control_items_[kPresentCurrentItem]->address);
   uint16_t read_length = control_items_[kPresentPositionItem]->data_length +
-                         control_items_[kPresentVelocityItem]->data_length +
-                         control_items_[kPresentCurrentItem]->data_length + 2;
+    control_items_[kPresentVelocityItem]->data_length +
+    control_items_[kPresentCurrentItem]->data_length + 2;
   if (!dynamixel_workbench_.addSyncReadHandler(start_address, read_length, &log)) {
     RCLCPP_FATAL(rclcpp::get_logger(kDynamixelHardware), "%s", log);
     return CallbackReturn::ERROR;
@@ -223,12 +226,15 @@ std::vector<hardware_interface::StateInterface> DynamixelHardware::export_state_
   RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "export_state_interfaces");
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (uint i = 0; i < info_.joints.size(); i++) {
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].state.position));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].state.velocity));
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].state.effort));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].state.position));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].state.velocity));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].state.effort));
   }
 
   return state_interfaces;
@@ -239,11 +245,14 @@ std::vector<hardware_interface::CommandInterface> DynamixelHardware::export_comm
   RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "export_command_interfaces");
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   for (uint i = 0; i < info_.joints.size(); i++) {
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joints_[i].command.position));
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joints_[i].command.velocity));
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &joints_[i].command.effort));
   }
 
@@ -259,13 +268,16 @@ CallbackReturn DynamixelHardware::on_activate(const rclcpp_lifecycle::State & /*
   return CallbackReturn::SUCCESS;
 }
 
-CallbackReturn DynamixelHardware::on_deactivate(const rclcpp_lifecycle::State & /* previous_state */)
+CallbackReturn DynamixelHardware::on_deactivate(
+  const rclcpp_lifecycle::State & /* previous_state */)
 {
   RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "deactivate");
   return CallbackReturn::SUCCESS;
 }
 
-return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcpp::Duration & /* period */)
+return_type DynamixelHardware::read(
+  const rclcpp::Time & /* time */,
+  const rclcpp::Duration & /* period */)
 {
   if (use_dummy_) {
     return return_type::OK;
@@ -280,29 +292,33 @@ return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcp
   const char * log = nullptr;
 
   if (!dynamixel_workbench_.syncRead(
-        kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(), &log)) {
+      kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(), &log))
+  {
     RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
     return return_type::ERROR;
   }
 
   if (!dynamixel_workbench_.getSyncReadData(
-        kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(),
-        control_items_[kPresentCurrentItem]->address,
-        control_items_[kPresentCurrentItem]->data_length, currents.data(), &log)) {
+      kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(),
+      control_items_[kPresentCurrentItem]->address,
+      control_items_[kPresentCurrentItem]->data_length, currents.data(), &log))
+  {
     RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
       }
 
   if (!dynamixel_workbench_.getSyncReadData(
-        kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(),
-        control_items_[kPresentVelocityItem]->address,
-        control_items_[kPresentVelocityItem]->data_length, velocities.data(), &log)) {
+      kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(),
+      control_items_[kPresentVelocityItem]->address,
+      control_items_[kPresentVelocityItem]->data_length, velocities.data(), &log))
+  {
     RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
       }
 
   if (!dynamixel_workbench_.getSyncReadData(
-        kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(),
-        control_items_[kPresentPositionItem]->address,
-        control_items_[kPresentPositionItem]->data_length, positions.data(), &log)) {
+      kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(),
+      control_items_[kPresentPositionItem]->address,
+      control_items_[kPresentPositionItem]->data_length, positions.data(), &log))
+  {
     RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
       }
 
@@ -315,7 +331,9 @@ return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcp
   return return_type::OK;
 }
 
-return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclcpp::Duration & /* period */)
+return_type DynamixelHardware::write(
+  const rclcpp::Time & /* time */,
+  const rclcpp::Duration & /* period */)
 {
   if (use_dummy_) {
     for (auto & joint : joints_) {
@@ -331,22 +349,26 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
 
   // Velocity control
   if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.velocity != j.prev_command.velocity; })) {
+      joints_.cbegin(), joints_.cend(), [](auto j) {
+        return j.command.velocity != j.prev_command.velocity;
+      }))
+  {
     set_control_mode(ControlMode::Velocity);
-    if(mode_changed_)
-    {
+    if (mode_changed_) {
       set_joint_params();
     }
     set_joint_velocities();
     return return_type::OK;
   }
-  
+
   // Position control
   if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.position != j.prev_command.position; })) {
+      joints_.cbegin(), joints_.cend(), [](auto j) {
+        return j.command.position != j.prev_command.position;
+      }))
+  {
     set_control_mode(ControlMode::ExtendedPosition);
-    if(mode_changed_)
-    {
+    if (mode_changed_) {
       set_joint_params();
     }
     set_joint_positions();
@@ -355,17 +377,19 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
 
   // Effort control
   if (std::any_of(
-        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.effort != j.prev_command.effort; })) {
-    set_control_mode(ControlMode::Current);
-    if(mode_changed_)
-    {
-      set_joint_params();
-    }
-    set_joint_currents();
-    return return_type::OK;
-  }
+        joints_.cbegin(), joints_.cend(), [](auto j) { return j.command.effort != j.prev_command.effort; })) 
+      {
+        set_control_mode(ControlMode::Current);
+        if(mode_changed_)
+        {
+          set_joint_params();
+        }
+        set_joint_currents();
+        return return_type::OK;
+      }
 
-  // if all command values are unchanged, then remain in existing control mode and set corresponding command values
+  // If all command values are unchanged, then remain in existing control mode and set
+  // corresponding command values
   switch (control_mode_) {
     case ControlMode::Velocity:
       set_joint_velocities();
@@ -384,7 +408,6 @@ return_type DynamixelHardware::write(const rclcpp::Time & /* time */, const rclc
       return return_type::ERROR;
       break;
   }
-
 }
 
 return_type DynamixelHardware::enable_torque(const bool enabled)
@@ -432,8 +455,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Velocity control");
-    if(control_mode_ != ControlMode::Velocity)
-    {
+    if (control_mode_ != ControlMode::Velocity) {
       mode_changed_ = true;
       control_mode_ = ControlMode::Velocity;
     }
@@ -457,8 +479,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
       }
     }
     RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "Extended Position control");
-    if(control_mode_ != ControlMode::ExtendedPosition)
-    {
+    if (control_mode_ != ControlMode::ExtendedPosition) {
       mode_changed_ = true;
       control_mode_ = ControlMode::ExtendedPosition;
     }
@@ -525,7 +546,8 @@ CallbackReturn DynamixelHardware::set_joint_positions()
       ids[i], static_cast<float>(joints_[i].command.position));
   }
   if (!dynamixel_workbench_.syncWrite(
-        kGoalPositionIndex, ids.data(), ids.size(), commands.data(), 1, &log)) {
+      kGoalPositionIndex, ids.data(), ids.size(), commands.data(), 1, &log))
+  {
     RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
   }
   return CallbackReturn::SUCCESS;
@@ -544,7 +566,8 @@ CallbackReturn DynamixelHardware::set_joint_velocities()
       ids[i], static_cast<float>(joints_[i].command.velocity));
   }
   if (!dynamixel_workbench_.syncWrite(
-        kGoalVelocityIndex, ids.data(), ids.size(), commands.data(), 1, &log)) {
+      kGoalVelocityIndex, ids.data(), ids.size(), commands.data(), 1, &log))
+  {
     RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
   }
   return CallbackReturn::SUCCESS;
@@ -580,7 +603,9 @@ CallbackReturn DynamixelHardware::set_joint_params()
           RCLCPP_FATAL(rclcpp::get_logger(kDynamixelHardware), "%s", log);
           return CallbackReturn::ERROR;
         }
-        RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "%s set to %d for joint %d", paramName, value, i);
+        RCLCPP_INFO(
+          rclcpp::get_logger(
+            kDynamixelHardware), "%s set to %d for joint %d", paramName, value, i);
       }
     }
   }


### PR DESCRIPTION
Hello, last year I worked on a project using `dynamixel_hardware`, during which I came across some problems and made some changes:

- Replaced the use of Position mode with ExtendedPosition mode
- Added support for Current control mode
- Included velocity and effort state updates in dummy mode
- Implemented the `on_configure` callback for initial communication with motors (instead of `on_init`, to align with this diagram: https://control.ros.org/rolling/_images/hardware_interface_lifecycle.png)

Couple of things to note:
- The hardware interface implementation doesn't handle the different control modes very elegantly and will switch between them when receiving different command types. So I would recommend ensuring only one controller is active on startup and providing ROS services to switch between them.
- According to the `ROS2_control` diagram linked above, powering the motors (`enable_torque(true)`) should be done in the `on_activate` callback. However I found that after `on_configure` completes the real-time `read`/`write` calls interfere with the dynamixel workbench functions, so I left it in `on_configure`. I believe similar issues are discussed here: https://github.com/dynamixel-community/dynamixel_hardware/pull/89

Feel free to review the changes and see if they can be included. I am no longer working on the project (and don't have access to the hardware) but can make some updates if needed. I also noted there has been some other PRs made recently, not sure what the compatibility is with my changes.

Cheers.