### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/dynamixel_hardware/CMakeLists.txt
+++ b/dynamixel_hardware/CMakeLists.txt
@@ -34,8 +34,8 @@ target_include_directories(
   PRIVATE
   include
 )
-ament_target_dependencies(
-  ${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   rclcpp
   rclcpp_lifecycle
   lifecycle_msgs


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
