### PR TITLE
Add support for disabling torque via hardware parameter

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -65,7 +65,8 @@ public:
   RCLCPP_SHARED_PTR_DEFINITIONS(DynamixelHardware)
 
   DYNAMIXEL_HARDWARE_PUBLIC
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+  CallbackReturn on_init(
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;

--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -101,7 +101,8 @@ private:
   std::map<const char * const, const ControlItem *> control_items_;
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
-  bool torque_enabled_{false};
+  bool should_enable_torque_{false}; // True if torque should be enabled. False otherwise.
+  bool torque_enabled_{false}; // True if torque is enabled. False otherwise.
   ControlMode control_mode_{ControlMode::Position};
   bool mode_changed_{false};
   bool use_dummy_{false};

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -48,10 +48,11 @@ constexpr const char * const kExtraJointParameters[] = {
   "Velocity_I_Gain",
 };
 
-CallbackReturn DynamixelHardware::on_init(const hardware_interface::HardwareInfo & info)
+CallbackReturn DynamixelHardware::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
   RCLCPP_DEBUG(rclcpp::get_logger(kDynamixelHardware), "configure");
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
 

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -82,6 +82,15 @@ CallbackReturn DynamixelHardware::on_init(
     return CallbackReturn::SUCCESS;
   }
 
+  if (
+    info_.hardware_parameters.find("enable_torque") != info_.hardware_parameters.end() &&
+    info_.hardware_parameters.at("enable_torque") == "false")
+  {
+    should_enable_torque_ = false;
+  } else {
+    should_enable_torque_ = true;
+  }
+
   auto usb_port = info_.hardware_parameters.at("usb_port");
   auto baud_rate = std::stoi(info_.hardware_parameters.at("baud_rate"));
   const char * log = nullptr;
@@ -105,7 +114,9 @@ CallbackReturn DynamixelHardware::on_init(
   enable_torque(false);
   set_control_mode(ControlMode::Position, true);
   set_joint_params();
-  enable_torque(true);
+  if (should_enable_torque_) {
+    enable_torque(true);
+  }
 
   const ControlItem * goal_position =
     dynamixel_workbench_.getItemInfo(joint_ids_[0], kGoalPositionItem);
@@ -411,7 +422,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
       control_mode_ = ControlMode::Velocity;
     }
 
-    if (torque_enabled) {
+    if (torque_enabled && should_enable_torque_) {
       enable_torque(true);
     }
     return return_type::OK;
@@ -435,7 +446,7 @@ return_type DynamixelHardware::set_control_mode(const ControlMode & mode, const 
       control_mode_ = ControlMode::Position;
     }
 
-    if (torque_enabled) {
+    if (torque_enabled && should_enable_torque_) {
       enable_torque(true);
     }
     return return_type::OK;


### PR DESCRIPTION
### Summary

This PR adds support for optionally disabling torque in the Dynamixel hardware interface. This feature is necessary for implementing a teleoperation setup where one robotic arm (the *leader*) is manually guided and the other (the *follower*) mimics its movements.

### Motivation

In the teleoperation setup, we use two Dynamixel-based robotic arms:

- **Leader Arm**: Controlled directly by a human operator. To allow manual movement, torque must be **disabled** on this arm.
- **Follower Arm**: Receives the leader's joint states and attempts to replicate the motion by applying them as desired joint positions.

The current Dynamixel hardware interface always enables torque on startup and after control mode changes, which prevents passive operation for the leader arm.

### Changes Introduced

- Added `enable_torque` hardware parameter (defaults to `true`).
- Introduced `should_enable_torque_` flag to control torque behavior.
- Conditioned torque enable calls based on this flag during init and control mode changes.

### Related Project
Teleoperation setup repository: [koch-v1-1](https://github.com/jess-moss/koch-v1-1)